### PR TITLE
fix typo in default_app_config

### DIFF
--- a/psqlextra/__init__.py
+++ b/psqlextra/__init__.py
@@ -4,4 +4,4 @@ __all__ = [
     'HStoreField'
 ]
 
-default_app_config = 'psqlextra.app.PostgresExtraAppConfig'
+default_app_config = 'psqlextra.apps.PostgresExtraAppConfig'


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.11/ref/applications/#for-application-authors

```python
# rock_n_roll/__init__.py

default_app_config = 'rock_n_roll.apps.RockNRollConfig'
```