### PR TITLE
Add missing semicola to examples in docs.

### DIFF
--- a/docs/manager.md
+++ b/docs/manager.md
@@ -248,7 +248,7 @@ class MyModel(PostgresModel):
 obj = (
     MyModel.objects
     .upsert_and_get(
-        conflict_target=['myfield']
+        conflict_target=['myfield'],
         fields=dict(myfield='beer')
     )
 )
@@ -256,7 +256,7 @@ obj = (
 id = (
     MyModel.objects
     .upsert(
-        conflict_target=['myfield']
+        conflict_target=['myfield'],
         fields=dict(myfield='beer')
     )
 )
@@ -264,7 +264,7 @@ id = (
 (
     MyModel.objects
     .bulk_upsert(
-        conflict_target=['myfield']
+        conflict_target=['myfield'],
         rows=[
             dict(myfield='beer'),
             dict(myfield='wine')

--- a/psqlextra/compiler.py
+++ b/psqlextra/compiler.py
@@ -48,7 +48,7 @@ class PostgresInsertCompiler(SQLInsertCompiler):
             rows = []
             for sql, params in self.as_sql(return_id):
                 cursor.execute(sql, params)
-                rows.append(cursor.fetchone())
+                rows.extend(cursor.fetchall())
 
         # create a mapping between column names and column value
         return [

--- a/psqlextra/manager/manager.py
+++ b/psqlextra/manager/manager.py
@@ -152,8 +152,8 @@ class PostgresQuerySet(models.QuerySet):
 
         if self.conflict_target or self.conflict_action:
             compiler = self._build_insert_compiler(rows)
-            compiler.execute_sql(return_id=True)
-            return
+            return compiler.execute_sql(return_id=True)
+
 
         # no special action required, use the standard Django bulk_create(..)
         super().bulk_create([self.model(**fields) for fields in rows])


### PR DESCRIPTION
Hi,
thanks for django-postgres-extra, which seems extremely useful.
I noticed that the examples in the docs are missing a couple of semicolons and added them.
This is a totally trivial change :)