### PR TITLE
add explicit parens around -> on the constraint

### DIFF
--- a/psqlextra/backend/hstore_required.py
+++ b/psqlextra/backend/hstore_required.py
@@ -5,7 +5,7 @@ class HStoreRequiredSchemaEditorMixin:
     sql_hstore_required_create = (
         'ALTER TABLE {table} '
         'ADD CONSTRAINT {name} '
-        'CHECK ({field}->\'{key}\' '
+        'CHECK (({field}->\'{key}\') '
         'IS NOT NULL)'
     )
 


### PR DESCRIPTION
`->` has very low priority so without them Postgres errors out:

```
django.db.utils.ProgrammingError: operator does not exist: hstore -> boolean
```

that's because foo->bar IS NOT NULL gets interpreted as foo->(bar IS NOT NULL) which is obviously not what we want
  