### PR TITLE
Cope with foreign keys which are primary keys

### DIFF
--- a/psqlextra/compiler.py
+++ b/psqlextra/compiler.py
@@ -155,12 +155,13 @@ class PostgresInsertCompiler(SQLInsertCompiler):
             (
                 'WITH insdata AS ('
                 '{insert} ON CONFLICT {conflict_target} DO UPDATE'
-                ' SET id = NULL WHERE FALSE RETURNING {returning})'
+                ' SET {pk_column} = NULL WHERE FALSE RETURNING {returning})'
                 ' SELECT * FROM insdata UNION ALL'
                 ' SELECT {returning} FROM {table} WHERE {where_clause} LIMIT 1;'
             ).format(
                 insert=sql,
                 conflict_target=conflict_target,
+                pk_column=self.qn(self.query.model._meta.pk.column),
                 returning=returning,
                 table=self.query.objs[0]._meta.db_table,
                 where_clause=where_clause

--- a/tests/test_on_conflict_nothing.py
+++ b/tests/test_on_conflict_nothing.py
@@ -62,8 +62,8 @@ def test_on_conflict_nothing_foreign_primary_key():
 
     obj1 = (
         model.objects
-        .on_conflict(['parent'], ConflictAction.NOTHING)
-        .insert_and_get(parent=referenced_obj, cookies='cheers')
+        .on_conflict(['parent_id'], ConflictAction.NOTHING)
+        .insert_and_get(parent_id=referenced_obj.pk, cookies='cheers')
     )
 
     obj1.refresh_from_db()
@@ -72,8 +72,8 @@ def test_on_conflict_nothing_foreign_primary_key():
 
     obj2 = (
         model.objects
-        .on_conflict(['parent'], ConflictAction.NOTHING)
-        .insert_and_get(parent=referenced_obj, cookies='choco')
+        .on_conflict(['parent_id'], ConflictAction.NOTHING)
+        .insert_and_get(parent_id=referenced_obj.pk, cookies='choco')
     )
 
     obj1.refresh_from_db()


### PR DESCRIPTION
This removes the assumption that all models have a field called 'id' and ensures that we use the correct column name for each field.

This aims to fix #40.