### PR TITLE
Cope with foreign key values being specified as objects

### DIFF
--- a/psqlextra/compiler.py
+++ b/psqlextra/compiler.py
@@ -268,10 +268,12 @@ class PostgresInsertCompiler(SQLInsertCompiler):
         field_name = self._normalize_field_name(field_name)
         field = self._get_model_field(field_name)
 
+        value = getattr(self.query.objs[0], field_name)
+
         return SQLInsertCompiler.prepare_value(
             self,
             field,
-            getattr(self.query.objs[0], field_name)
+            self.pre_save_val(field, value)
         )
 
     def _normalize_field_name(self, field_name) -> str:

--- a/tests/test_on_conflict_nothing.py
+++ b/tests/test_on_conflict_nothing.py
@@ -1,3 +1,4 @@
+import pytest
 from django.db import models
 
 from psqlextra.fields import HStoreField
@@ -39,3 +40,52 @@ def test_on_conflict_nothing():
     assert obj1.cookies == 'cheers'
     assert obj2.title['key1'] == 'beer'
     assert obj2.cookies == 'cheers'
+
+
+def test_on_conflict_nothing_foreign_key():
+    """
+    Tests whether simple insert NOTHING works correctly when the potentially
+    conflicting field is a foreign key.
+    """
+
+    other_model = get_fake_model({})
+
+    model = get_fake_model({
+        'other': models.OneToOneField(
+            other_model,
+            on_delete=models.CASCADE,
+        ),
+    })
+
+    other_obj_1 = other_model.objects.create()
+    other_obj_2 = other_model.objects.create()
+
+    obj1 = (
+        model.objects
+        .on_conflict(['other'], ConflictAction.NOTHING)
+        .insert_and_get(other=other_obj_1)
+    )
+
+    obj1.refresh_from_db()
+    assert obj1.other == other_obj_1
+
+    with pytest.raises(ValueError):
+        (
+            model.objects
+            .on_conflict(['other'], ConflictAction.NOTHING)
+            .insert_and_get(other=obj1)
+        )
+
+    obj2 = (
+        model.objects
+        .on_conflict(['other'], ConflictAction.NOTHING)
+        .insert_and_get(other=other_obj_2)
+    )
+
+    obj1.refresh_from_db()
+    obj2.refresh_from_db()
+
+    # assert that the 'other' field didn't change
+    assert obj1.id == obj2.id
+    assert obj1.other == other_obj_1
+    assert obj2.other == other_obj_1

--- a/tests/test_on_conflict_update.py
+++ b/tests/test_on_conflict_update.py
@@ -1,3 +1,4 @@
+import pytest
 from django.db import models
 
 from psqlextra.fields import HStoreField
@@ -39,3 +40,52 @@ def test_on_conflict_update():
     assert obj1.cookies == 'choco'
     assert obj2.title['key1'] == 'beer'
     assert obj2.cookies == 'choco'
+
+
+def test_on_conflict_update_foreign_key():
+    """
+    Tests whether simple upsert works correctly when the conflicting field is a
+    foreign key.
+    """
+
+    other_model = get_fake_model({})
+
+    model = get_fake_model({
+        'other': models.OneToOneField(
+            other_model,
+            on_delete=models.CASCADE,
+        ),
+    })
+
+    other_obj_1 = other_model.objects.create()
+    other_obj_2 = other_model.objects.create()
+
+    obj1 = (
+        model.objects
+        .on_conflict(['other'], ConflictAction.NOTHING)
+        .insert_and_get(other=other_obj_1)
+    )
+
+    obj1.refresh_from_db()
+    assert obj1.other == other_obj_1
+
+    with pytest.raises(ValueError):
+        (
+            model.objects
+            .on_conflict(['other'], ConflictAction.NOTHING)
+            .insert_and_get(other=obj1)
+        )
+
+    obj2 = (
+        model.objects
+        .on_conflict(['other'], ConflictAction.UPDATE)
+        .insert_and_get(other=other_obj_2)
+    )
+
+    obj1.refresh_from_db()
+    obj2.refresh_from_db()
+
+    # assert that the 'other' field did change
+    assert obj1.id == obj2.id
+    assert obj1.other == other_obj_2
+    assert obj2.other == other_obj_2


### PR DESCRIPTION
Use the same 'pre_save_val' mechanism as Django does inside 'SQLInsertCompiler.as_sql'.

Aims to fix #43.