### PR TITLE
Have `PostgresQuerySet.insert` always return the primary key

### DIFF
--- a/psqlextra/manager/manager.py
+++ b/psqlextra/manager/manager.py
@@ -187,12 +187,12 @@ class PostgresQuerySet(models.QuerySet):
         if self.conflict_target or self.conflict_action:
             compiler = self._build_insert_compiler([fields])
             rows = compiler.execute_sql(return_id=True)
-            if 'id' in rows[0]:
-                return rows[0]['id']
-            return None
+
+            pk_field_name = self.model._meta.pk.name
+            return rows[0][pk_field_name]
 
         # no special action required, use the standard Django create(..)
-        return super().create(**fields).id
+        return super().create(**fields).pk
 
     def insert_and_get(self, **fields):
         """Creates a new record in the database and then gets

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -1,0 +1,100 @@
+from django.db import models
+
+from psqlextra.query import ConflictAction
+from .util import get_fake_model
+
+
+def test_insert():
+    """Tests whether inserts works when the primary key is explicitly specified."""
+
+    model = get_fake_model({
+        'cookies': models.CharField(max_length=255, null=True),
+    })
+
+    pk = (
+        model.objects.all()
+        .insert(
+            cookies='some-cookies',
+        )
+    )
+
+    assert pk is not None
+
+    obj1 = model.objects.get()
+    assert obj1.pk == pk
+    assert obj1.cookies == 'some-cookies'
+
+
+def test_insert_explicit_pk():
+    """Tests whether inserts works when the primary key is explicitly specified."""
+
+    model = get_fake_model({
+        'name': models.CharField(max_length=255, primary_key=True),
+        'cookies': models.CharField(max_length=255, null=True),
+    })
+
+    pk = (
+        model.objects.all()
+        .insert(
+            name='the-object',
+            cookies='some-cookies',
+        )
+    )
+
+    assert pk == 'the-object'
+
+    obj1 = model.objects.get()
+    assert obj1.pk == 'the-object'
+    assert obj1.name == 'the-object'
+    assert obj1.cookies == 'some-cookies'
+
+
+def test_insert_on_conflict():
+    """Tests whether inserts works when a conflict is anticipated."""
+
+    model = get_fake_model({
+        'name': models.CharField(max_length=255, unique=True),
+        'cookies': models.CharField(max_length=255, null=True),
+    })
+
+    pk = (
+        model.objects.on_conflict([('pk')], ConflictAction.NOTHING)
+        .insert(
+            name='the-object',
+            cookies='some-cookies',
+        )
+    )
+
+    assert pk is not None
+
+    obj1 = model.objects.get()
+    assert obj1.pk == pk
+    assert obj1.name == 'the-object'
+    assert obj1.cookies == 'some-cookies'
+
+
+def test_insert_on_conflict_explicit_pk():
+    """
+    Tests whether inserts works when a conflict is anticipated and the primary
+    key is explicitly specified.
+    """
+
+    model = get_fake_model({
+        'name': models.CharField(max_length=255, primary_key=True),
+        'cookies': models.CharField(max_length=255, null=True),
+    })
+
+    pk = (
+        model.objects.on_conflict([('name')], ConflictAction.NOTHING)
+        .insert(
+            name='the-object',
+            cookies='some-cookies',
+        )
+    )
+
+    assert pk == 'the-object'
+
+    obj1 = model.objects.get()
+    assert obj1.pk == 'the-object'
+    assert obj1.name == 'the-object'
+    assert obj1.cookies == 'some-cookies'


### PR DESCRIPTION
This fixes #48 and ensures that objects which specify an explicit primary key value will have that value returned from 'insert'.

This makes `insert` reliably usable for models which don't have an `id` field (which previously `AttributeError`ed or returned `None`, depending on whether a conflict was anticipated).

Note: this is potentially quietly breaking for models which:
- specified a non-`id` primary key, and
- also had a separate `id` field

This scenario seems sufficiently unlikely to be worth the fix.