### PR TITLE
Fix bug: rename annotation_mask

### DIFF
--- a/psqlextra/query.py
+++ b/psqlextra/query.py
@@ -40,8 +40,10 @@ class PostgresQuery(sql.Query):
                     ' is no annotation named "{old_name}".'
                 ).format(old_name=old_name, new_name=new_name))
 
-            del self.annotations[old_name]
-            self.annotations[new_name] = annotation
+            self._annotations = OrderedDict(
+                [(new_name, v) if k == old_name else (k, v) for k, v in self._annotations.items()])
+            self.set_annotation_mask(
+                (new_name if v == old_name else v for v in self.annotation_select_mask))
 
     def add_join_conditions(self, conditions: Dict[str, Any]) -> None:
         """Adds an extra condition to an existing JOIN.


### PR DESCRIPTION
# Abstract
When the name of an existing field on the model is used as the alias name, `annotate` function renames the fields.
https://github.com/SectorLabs/django-postgres-extra/blob/f4ce6ad3fb53ad84da3f57bd37345481df5b2f1a/psqlextra/manager/manager.py#L46-L57

After that, `rename_annotations` renames the fields to the original name again.
https://github.com/SectorLabs/django-postgres-extra/blob/76b68603e0199e29aa6110099858b2cb3f8655da/psqlextra/query.py#L34-L44

However, `annotation_select_mask` is not changed.
As a result, the renamed fields are lost because `_annotation_select_cache ` is generated by `annotation_select_mask`.
https://github.com/django/django/blob/952f05a6db2665d83c04075119285f2164b03432/django/db/models/sql/query.py#L2022-L2027

In addition, though `self.annotations` is `OrderedDict`, order is destroyed in the following code.
https://github.com/SectorLabs/django-postgres-extra/blob/76b68603e0199e29aa6110099858b2cb3f8655da/psqlextra/query.py#L43-L44

# Sample
https://github.com/knqyf263/psqlextra_fix

In `test_annotation_bug`, `description` is not selected correctly.
https://github.com/knqyf263/psqlextra_fix/blob/master/users/tests.py#L10-L14

In `test_union_exception`, `ValueError` exception is thrown.
This is because the number of fields does not match the number of converters due to `annotation_select_mask` bug.
https://github.com/knqyf263/psqlextra_fix/blob/master/users/tests.py#L16-L23

# Fix
- Chang to keep order of `self.annotations`.
- Also rename `self.annotation_select_mask`.

I'm not sure if this fix is correct, please review me!
