### PR TITLE
Updated README and docs to use consistent django app name; psqlextra

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Installation
 
         λ pip install django-postgres-extra
 
-2. Add ``postgres_extra`` and ``django.contrib.postgres`` to your ``INSTALLED_APPS``:
+2. Add ``psqlextra`` and ``django.contrib.postgres`` to your ``INSTALLED_APPS``:
 
    .. code-block:: python
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Explore the documentation to learn about all features:
 
         $ pip install django-postgres-extra
 
-2. Add `postgres_extra` and `django.contrib.postgres` to your `INSTALLED_APPS`:
+2. Add `psqlextra` and `django.contrib.postgres` to your `INSTALLED_APPS`:
 
         INSTALLED_APPS = [
             ....


### PR DESCRIPTION
Basic doc update. 
Docs mentioned adding `postgres_extra` to the `INSTALLED_APPS` section, but then showed `psqlextra` as being the installed app name. Modified the two instances to improve consistency in the directions. 

