### PR TITLE
Deconstruct empty list of required and uniqueness keyword arguments

### DIFF
--- a/psqlextra/fields/hstore_field.py
+++ b/psqlextra/fields/hstore_field.py
@@ -1,8 +1,8 @@
 from typing import List, Tuple, Union
 
+from django.contrib.postgres.fields import HStoreField as DjangoHStoreField
 from django.db.models.expressions import Expression
 from django.db.models.fields import Field
-from django.contrib.postgres.fields import HStoreField as DjangoHStoreField
 
 from psqlextra.expressions import HStoreValue
 
@@ -59,10 +59,10 @@ class HStoreField(DjangoHStoreField):
         name, path, args, kwargs = super(
             HStoreField, self).deconstruct()
 
-        if self.uniqueness:
+        if self.uniqueness is not None:
             kwargs['uniqueness'] = self.uniqueness
 
-        if self.required:
+        if self.required is not None:
             kwargs['required'] = self.required
 
         return name, path, args, kwargs

--- a/tests/test_hstore_field.py
+++ b/tests/test_hstore_field.py
@@ -7,7 +7,7 @@ def test_deconstruct():
     """Tests whether the :see:HStoreField's deconstruct()
     method works properly."""
 
-    original_kwargs = dict(uniqueness=['beer', 'other'])
+    original_kwargs = dict(uniqueness=['beer', 'other'], required=[])
     _, _, _, new_kwargs = HStoreField(**original_kwargs).deconstruct()
 
     for key, value in original_kwargs.items():


### PR DESCRIPTION
This makes it consistent with base django field which deconstructs all fields which are different to default arguments.

Additionally does it fix issues for custom fields which depend on differentiating between `required=None` and `required=[]` like `LocalizedField`.

See https://github.com/SectorLabs/django-localized-fields/issues/58

This is just a suggestion but https://github.com/SectorLabs/django-localized-fields/issues/58 could also be fixed differently, so open to suggestions.