### PR TITLE
Ensure bulk_upsert always returns an iterable

### DIFF
--- a/psqlextra/manager/manager.py
+++ b/psqlextra/manager/manager.py
@@ -297,7 +297,7 @@ class PostgresQuerySet(models.QuerySet):
         """
 
         if not rows or len(rows) <= 0:
-            return
+            return []
 
         self.on_conflict(conflict_target, ConflictAction.UPDATE, index_predicate)
         return self.bulk_insert(rows)


### PR DESCRIPTION
The return value of `bulk_upsert` is not consistent. Usually, it returns a list of `dict`. However, the sanity check added in c6686f141bb342dafa73ff91a6960027b6f77581 makes sure that `bulk_upsert` returns `None` when no rows (or an empty list of rows) have been passed.

As a result, this pull request intends to change that by returning an empty list when the sanity check bypasses the rest of the code.