### PR TITLE
Ensure bulk_upsert accepts any iterable for rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist/
 # Ignore temporary tox environments
 .tox/
 .pytest_cache/
+
+# Ignore PyCharm / IntelliJ files
+.idea/

--- a/tests/test_upsert.py
+++ b/tests/test_upsert.py
@@ -146,3 +146,59 @@ def test_bulk_upsert_return_models():
     for index, obj in enumerate(objs, 1):
         assert isinstance(obj, model)
         assert obj.id == index
+
+
+def test_bulk_upsert_accepts_getitem_iterable():
+    """Tests whether an iterable only implementing
+    the __getitem__ method works correctly."""
+
+    class GetItemIterable:
+        def __init__(self, items):
+            self.items = items
+        def __getitem__(self, key):
+            return self.items[key]
+
+    model = get_fake_model(
+        {
+            "id": models.BigAutoField(primary_key=True),
+            "name": models.CharField(max_length=255, unique=True),
+        }
+    )
+
+    rows = GetItemIterable([dict(name="John Smith"), dict(name="Jane Doe")])
+
+    objs = model.objects.bulk_upsert(
+        conflict_target=["name"], rows=rows, return_model=True
+    )
+
+    for index, obj in enumerate(objs, 1):
+        assert isinstance(obj, model)
+        assert obj.id == index
+
+
+def test_bulk_upsert_accepts_iter_iterable():
+    """Tests whether an iterable only implementing
+    the __iter__ method works correctly."""
+
+    class IterIterable:
+        def __init__(self, items):
+            self.items = items
+        def __iter__(self):
+            return iter(self.items)
+
+    model = get_fake_model(
+        {
+            "id": models.BigAutoField(primary_key=True),
+            "name": models.CharField(max_length=255, unique=True),
+        }
+    )
+
+    rows = IterIterable([dict(name="John Smith"), dict(name="Jane Doe")])
+
+    objs = model.objects.bulk_upsert(
+        conflict_target=["name"], rows=rows, return_model=True
+    )
+
+    for index, obj in enumerate(objs, 1):
+        assert isinstance(obj, model)
+        assert obj.id == index


### PR DESCRIPTION
This updates the `bulk_insert` and `bulk_update` methods to allows `rows` to be any object that's an [iterable](https://docs.python.org/3/glossary.html#term-iterable) (i.e. implements `__getitem__` and/or `__iter__`).

Currently, the two methods require rows to be a list (or specifically, an object that supports indexing). I ran into this when I was using a dict to generate the rows to submit.  Here's a contrived example:
```python
    rows = {
        1: {pk: 1, val1: False, val2: False},
        4: {pk: 4, val1: False, val2: False},  
    }
    for pk in pks_where_val1_is_true:
        records[pk]["val1"] = True
    for pk in pks_where_val2_is_true:
        records[pk]["val2"] = True
    model.objects.bulk_upsert(
        conflict_target=["name"], rows=rows.values(), return_model=True
    )
```
Since `rows.values()` returns a [dictionary view object](https://docs.python.org/3/library/stdtypes.html#dict-views), it doesn't support indexing (e.g. `rows[0]`). The existing logic that assumes the `rows` argument supports indexing causes an exception.  This PR removes that requirement, allowing any iterable to be passed without first being converted to a `list`.

I've also included tests 🎉