### PR TITLE
Fix PostgresModelState render method

### DIFF
--- a/psqlextra/backend/migrations/state/model.py
+++ b/psqlextra/backend/migrations/state/model.py
@@ -68,7 +68,7 @@ class PostgresModelState(ModelState):
                 "Cannot resolve one or more bases from %r" % (self.bases,)
             )
 
-        fields = {name: field.clone() for name, field in self.fields}
+        fields = {name: field.clone() for name, field in self.fields.items()}
         meta = type(
             "Meta",
             (),


### PR DESCRIPTION
Iterate trough `self.fields` leads to this error:
`AttributeError: 'str' object has no attribute 'clone'`

Iterating on `self.fields.items()` resolve the problem