### PR TITLE
Get the items() from the dictionary

### DIFF
--- a/psqlextra/backend/migrations/state/model.py
+++ b/psqlextra/backend/migrations/state/model.py
@@ -68,7 +68,7 @@ class PostgresModelState(ModelState):
                 "Cannot resolve one or more bases from %r" % (self.bases,)
             )
 
-        fields = {name: field.clone() for name, field in self.fields}
+        fields = {name: field.clone() for name, field in self.fields.items()}
         meta = type(
             "Meta",
             (),


### PR DESCRIPTION
I kept running into this issue with Django 3.1

```
Traceback (most recent call last):
  File "manage.py", line 30, in <module>
    main()
  File "manage.py", line 26, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 330, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 371, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.7/site-packages/psqlextra/management/commands/pgmakemigrations.py", line 11, in handle
    return super().handle(*app_labels, **options)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 85, in wrapped
    res = handle_func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/commands/makemigrations.py", line 168, in handle
    migration_name=self.migration_name,
  File "/usr/local/lib/python3.7/site-packages/django/db/migrations/autodetector.py", line 43, in changes
    changes = self._detect_changes(convert_apps, graph)
  File "/usr/local/lib/python3.7/site-packages/django/db/migrations/autodetector.py", line 129, in _detect_changes
    self.new_apps = self.to_state.apps
  File "/usr/local/lib/python3.7/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/usr/local/lib/python3.7/site-packages/django/db/migrations/state.py", line 208, in apps
    return StateApps(self.real_apps, self.models)
  File "/usr/local/lib/python3.7/site-packages/django/db/migrations/state.py", line 271, in __init__
    self.render_multiple([*models.values(), *self.real_models])
  File "/usr/local/lib/python3.7/site-packages/django/db/migrations/state.py", line 306, in render_multiple
    model.render(self)
  File "/usr/local/lib/python3.7/site-packages/psqlextra/backend/migrations/state/model.py", line 71, in render
    fields = {name: field.clone() for name, field in self.fields}
  File "/usr/local/lib/python3.7/site-packages/psqlextra/backend/migrations/state/model.py", line 71, in <dictcomp>
    fields = {name: field.clone() for name, field in self.fields}
AttributeError: 'str' object has no attribute 'clone'
```

After doing some digging, the culprit seems to be this subtle comprehension.