### PR TITLE
Support using a generator for rows in bulk_insert and bulk_upsert

### DIFF
--- a/tests/test_upsert.py
+++ b/tests/test_upsert.py
@@ -280,6 +280,7 @@ def test_bulk_upsert_accepts_getitem_iterable():
         conflict_target=["name"], rows=rows, return_model=True
     )
 
+    assert len(objs) == 2
     for index, obj in enumerate(objs, 1):
         assert isinstance(obj, model)
         assert obj.id == index
@@ -309,6 +310,31 @@ def test_bulk_upsert_accepts_iter_iterable():
         conflict_target=["name"], rows=rows, return_model=True
     )
 
+    assert len(objs) == 2
+    for index, obj in enumerate(objs, 1):
+        assert isinstance(obj, model)
+        assert obj.id == index
+
+
+def test_bulk_upsert_accepts_generator():
+    """Tests whether a generator works correctly."""
+
+    model = get_fake_model(
+        {
+            "id": models.BigAutoField(primary_key=True),
+            "name": models.CharField(max_length=255, unique=True),
+        }
+    )
+
+    def rows():
+        yield dict(name="John Smith")
+        yield dict(name="Jane Doe")
+
+    objs = model.objects.bulk_upsert(
+        conflict_target=["name"], rows=rows(), return_model=True
+    )
+
+    assert len(objs) == 2
     for index, obj in enumerate(objs, 1):
         assert isinstance(obj, model)
         assert obj.id == index


### PR DESCRIPTION
This updates the `bulk_insert` and `bulk_update` methods to allow the `rows` parameter to be a [generator object](https://wiki.python.org/moin/Generators).

@utapyngo explains why generator objects currently fail [here](https://github.com/SectorLabs/django-postgres-extra/pull/83#issuecomment-794983592) in #83:

> This fails when a generator expression is passed as `rows`. The first `is_empty` call consumes the generator, and the StopIteration exception is raised when trying to get the first row:
> 
> ```
>   File "psqlextra/manager/manager.py", line 633, in bulk_upsert
>     conflict_target, rows, index_predicate, return_model
>   File "psqlextra/manager/manager.py", line 336, in bulk_upsert
>     return self.bulk_insert(rows, return_model)
>   File "psqlextra/manager/manager.py", line 169, in bulk_insert
>     compiler = self._build_insert_compiler(rows)
>   File "psqlextra/manager/manager.py", line 357, in _build_insert_compiler
>     first_row = next(rows_iter)
> StopIteration
> ```

This PR fixes the problem by detecting when `rows` is a generator object and converts it to a `list`:
```
def bulk_insert(
        self,
        rows: Iterable[Dict],
        return_model: bool = False,
        using: Optional[str] = None,
    ):
    rows = _resolve_iterator_to_list(rows)
    # ...rest of method code

def bulk_upsert(
        self,
        conflict_target: ConflictTarget,
        rows: Iterable[Dict],
        index_predicate: Optional[Union[Expression, Q, str]] = None,
        return_model: bool = False,
        using: Optional[str] = None,
        update_condition: Optional[Union[Expression, Q, str]] = None,
    ):
    rows = _resolve_iterator_to_list(rows)
    # rest of method code...

def _resolve_iterator_to_list(rows: Iterable[Dict]):
    if isinstance(rows, Iterator):
        return list(rows)
    return rows
```