### PR TITLE
Skip partitioning tests that depend on Postgres >= 11 if lesser version is available

### DIFF
--- a/tests/test_migration_operations.py
+++ b/tests/test_migration_operations.py
@@ -78,6 +78,7 @@ def create_model():
     return _create_model
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 @pytest.mark.parametrize("method", PostgresPartitioningMethod.all())
 def test_migration_operations_create_partitioned_table(method, create_model):
     """Tests whether the see :PostgresCreatePartitionedModel operation works as
@@ -95,6 +96,7 @@ def test_migration_operations_create_partitioned_table(method, create_model):
     assert not _partitioned_table_exists(create_operation)
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 @pytest.mark.parametrize("method", PostgresPartitioningMethod.all())
 def test_migration_operations_delete_partitioned_table(method, create_model):
     """Tests whether the see :PostgresDeletePartitionedModel operation works as
@@ -126,6 +128,7 @@ def test_migration_operations_delete_partitioned_table(method, create_model):
     assert _partitioned_table_exists(create_operation)
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 @pytest.mark.parametrize(
     "method,add_partition_operation",
     [
@@ -173,6 +176,7 @@ def test_migration_operations_add_partition(
     assert not _partition_exists(create_operation, add_partition_operation)
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 @pytest.mark.parametrize(
     "method,add_partition_operation,delete_partition_operation",
     [

--- a/tests/test_partitioning_time.py
+++ b/tests/test_partitioning_time.py
@@ -21,6 +21,7 @@ def _get_partitioned_table(model):
     return db_introspection.get_partitioned_table(model._meta.db_table)
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_partitioning_time_yearly_apply():
     """Tests whether automatically creating new partitions ahead yearly works
     as expected."""
@@ -56,6 +57,7 @@ def test_partitioning_time_yearly_apply():
     assert table.partitions[2].name == "2021"
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_partitioning_time_monthly_apply():
     """Tests whether automatically creating new partitions ahead monthly works
     as expected."""
@@ -113,6 +115,7 @@ def test_partitioning_time_monthly_apply():
     assert table.partitions[13].name == "2020_feb"
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_partitioning_time_weekly_apply():
     """Tests whether automatically creating new partitions ahead weekly works
     as expected."""
@@ -162,6 +165,7 @@ def test_partitioning_time_weekly_apply():
     assert table.partitions[6].name == "2019_week_23"
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_partitioning_time_daily_apply():
     """Tests whether automatically creating new partitions ahead daily works as
     expected."""
@@ -211,6 +215,7 @@ def test_partitioning_time_daily_apply():
     assert table.partitions[6].name == "2019_jun_04"
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_partitioning_time_monthly_apply_insert():
     """Tests whether automatically created monthly partitions line up
     perfectly."""
@@ -247,6 +252,7 @@ def test_partitioning_time_monthly_apply_insert():
     model.objects.create(timestamp=datetime.date(2019, 3, 2))
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_partitioning_time_weekly_apply_insert():
     """Tests whether automatically created weekly partitions line up
     perfectly."""
@@ -287,6 +293,7 @@ def test_partitioning_time_weekly_apply_insert():
     model.objects.create(timestamp=datetime.date(2019, 1, 22))
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_partitioning_time_daily_apply_insert():
     """Tests whether automatically created daily partitions line up
     perfectly."""
@@ -326,6 +333,7 @@ def test_partitioning_time_daily_apply_insert():
     model.objects.create(timestamp=datetime.date(2019, 1, 10))
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 @pytest.mark.parametrize(
     "kwargs,partition_names",
     [
@@ -354,6 +362,7 @@ def test_partitioning_time_multiple(kwargs, partition_names):
     assert partition_names == [par.name for par in table.partitions]
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 @pytest.mark.parametrize(
     "kwargs,timepoints",
     [
@@ -410,6 +419,7 @@ def test_partitioning_time_delete(kwargs, timepoints):
             assert len(table.partitions) == partition_count
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_partitioning_time_delete_ignore_manual():
     """Tests whether partitions that were created manually are ignored.
 

--- a/tests/test_schema_editor_partitioning.py
+++ b/tests/test_schema_editor_partitioning.py
@@ -10,6 +10,7 @@ from . import db_introspection
 from .fake_model import define_fake_partitioned_model
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_schema_editor_create_delete_partitioned_model_range():
     """Tests whether creating a partitioned model and adding a list partition
     to it using the :see:PostgresSchemaEditor works."""
@@ -42,6 +43,7 @@ def test_schema_editor_create_delete_partitioned_model_range():
     assert len(partitions) == 0
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_schema_editor_create_delete_partitioned_model_list():
     """Tests whether creating a partitioned model and adding a range partition
     to it using the :see:PostgresSchemaEditor works."""
@@ -74,6 +76,7 @@ def test_schema_editor_create_delete_partitioned_model_list():
     assert len(partitions) == 0
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_schema_editor_create_delete_partitioned_model_default():
     """Tests whether creating a partitioned model and adding a default
     partition to it using the :see:PostgresSchemaEditor works."""
@@ -106,6 +109,7 @@ def test_schema_editor_create_delete_partitioned_model_default():
     assert len(partitions) == 0
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_schema_editor_create_partitioned_model_no_method():
     """Tests whether its possible to create a partitioned model without
     explicitly setting a partitioning method.
@@ -144,6 +148,7 @@ def test_schema_editor_create_partitioned_model_no_key():
         schema_editor.create_partitioned_model(model)
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_schema_editor_add_range_partition():
     """Tests whether adding a range partition works."""
 
@@ -176,6 +181,7 @@ def test_schema_editor_add_range_partition():
     assert len(table.partitions) == 0
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 def test_schema_editor_add_list_partition():
     """Tests whether adding a list partition works."""
 
@@ -204,6 +210,7 @@ def test_schema_editor_add_list_partition():
     assert len(table.partitions) == 0
 
 
+@pytest.mark.skip_pg_version(lt=110000)
 @pytest.mark.parametrize(
     "method,key",
     [


### PR DESCRIPTION
With Postgres versions < 11 some tests fail because they depend on primary keys for partitioned tables, which was implemented starting with 11.x only.
Rather than requiring higher Postgres version for this project, I think it's right to just skip these tests on older versions (9.x is still officially supported and looks like 10.x will be also for a long time)
Initially I thought on xfail-ing these tests, but then I changed to skipping because failure in this case doesn't provide us any useful information.