### PR TITLE
Fix RemovedInDjango41Warning

### DIFF
--- a/psqlextra/__init__.py
+++ b/psqlextra/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = "psqlextra.apps.PostgresExtraAppConfig"
+import django
+
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "psqlextra.apps.PostgresExtraAppConfig"


### PR DESCRIPTION
RemovedInDjango41Warning: 'psqlextra' defines default_app_config = 'psqlextra.apps.PostgresExtraAppConfig'. Django now detects this configuration automatically. You can remove default_app_config.