### PR TITLE
Hash partitioning

### DIFF
--- a/docs/source/table_partitioning.rst
+++ b/docs/source/table_partitioning.rst
@@ -42,6 +42,7 @@ Inherit your model from :class:`psqlextra.models.PostgresPartitionedModel` and d
 
 * Use :attr:`psqlextra.types.PostgresPartitioningMethod.RANGE` to ``PARTITION BY RANGE``
 * Use :attr:`psqlextra.types.PostgresPartitioningMethod.LIST` to ``PARTITION BY LIST``
+* Use :attr:`psqlextra.types.PostgresPartitioningMethod.HASH` to ``PARTITION BY HASH``
 
 .. code-block:: python
 

--- a/docs/source/table_partitioning.rst
+++ b/docs/source/table_partitioning.rst
@@ -20,6 +20,7 @@ The following partitioning methods are available:
 
 * ``PARTITION BY RANGE``
 * ``PARTITION BY LIST``
+* ``PARTITION BY HASH``
 
 .. note::
 

--- a/psqlextra/backend/introspection.py
+++ b/psqlextra/backend/introspection.py
@@ -11,6 +11,7 @@ PARTITIONING_STRATEGY_TO_METHOD = {
     "h": PostgresPartitioningMethod.HASH,
 }
 
+
 @dataclass
 class PostgresIntrospectedPartitionTable:
     """Data container for information about a partition."""
@@ -151,6 +152,7 @@ class PostgresIntrospection(base_impl.introspection()):
                         CASE partstrat
                             WHEN 'l' THEN 'list'
                             WHEN 'r' THEN 'range'
+                            WHEN 'h' THEN 'hash'
                         END AS partition_strategy,
                         Unnest(partattrs) column_index
                  FROM pg_partitioned_table) pt

--- a/psqlextra/backend/introspection.py
+++ b/psqlextra/backend/introspection.py
@@ -5,6 +5,11 @@ from psqlextra.types import PostgresPartitioningMethod
 
 from . import base_impl
 
+PARTITIONING_STRATEGY_TO_METHOD = {
+    "r": PostgresPartitioningMethod.RANGE,
+    "l": PostgresPartitioningMethod.LIST,
+    "h": PostgresPartitioningMethod.HASH,
+}
 
 @dataclass
 class PostgresIntrospectedPartitionTable:
@@ -64,9 +69,7 @@ class PostgresIntrospection(base_impl.introspection()):
         return [
             PostgresIntrospectedPartitonedTable(
                 name=row[0],
-                method=PostgresPartitioningMethod.RANGE
-                if row[1] == "r"
-                else PostgresPartitioningMethod.LIST,
+                method=PARTITIONING_STRATEGY_TO_METHOD[row[1]],
                 key=self.get_partition_key(cursor, row[0]),
                 partitions=self.get_partitions(cursor, row[0]),
             )

--- a/psqlextra/backend/migrations/operations/__init__.py
+++ b/psqlextra/backend/migrations/operations/__init__.py
@@ -1,4 +1,5 @@
 from .add_default_partition import PostgresAddDefaultPartition
+from .add_hash_partition import PostgresAddHashPartition
 from .add_list_partition import PostgresAddListPartition
 from .add_range_partition import PostgresAddRangePartition
 from .apply_state import ApplyState
@@ -6,6 +7,7 @@ from .create_materialized_view_model import PostgresCreateMaterializedViewModel
 from .create_partitioned_model import PostgresCreatePartitionedModel
 from .create_view_model import PostgresCreateViewModel
 from .delete_default_partition import PostgresDeleteDefaultPartition
+from .delete_hash_partition import PostgresDeleteHashPartition
 from .delete_list_partition import PostgresDeleteListPartition
 from .delete_materialized_view_model import PostgresDeleteMaterializedViewModel
 from .delete_partitioned_model import PostgresDeletePartitionedModel
@@ -14,12 +16,14 @@ from .delete_view_model import PostgresDeleteViewModel
 
 __all__ = [
     "ApplyState",
-    "PostgresAddRangePartition",
+    "PostgresAddHashPartition",
     "PostgresAddListPartition",
+    "PostgresAddRangePartition",
     "PostgresAddDefaultPartition",
     "PostgresDeleteDefaultPartition",
-    "PostgresDeleteRangePartition",
+    "PostgresDeleteHashPartition",
     "PostgresDeleteListPartition",
+    "PostgresDeleteRangePartition",
     "PostgresCreatePartitionedModel",
     "PostgresDeletePartitionedModel",
     "PostgresCreateViewModel",

--- a/psqlextra/backend/migrations/operations/add_hash_partition.py
+++ b/psqlextra/backend/migrations/operations/add_hash_partition.py
@@ -1,0 +1,71 @@
+from psqlextra.backend.migrations.state import PostgresHashPartitionState
+
+from .partition import PostgresPartitionOperation
+
+
+class PostgresAddHashPartition(PostgresPartitionOperation):
+    """
+    Adds a new hash partition to a :see:PartitionedPostgresModel.
+    Each partition will hold the rows for which the hash value of the partition
+    key divided by the specified modulus will produce the specified remainder.
+    """
+
+    def __init__(self, model_name: str, name: str, modulus: int, remainder: int):
+        """Initializes new instance of :see:AddHashPartition.
+        Arguments:
+            model_name:
+                The name of the :see:PartitionedPostgresModel.
+
+            name:
+                The name to give to the new partition table.
+
+            modulus:
+                Integer value by which the key is divided.
+
+            remainder:
+                The remainder of the hash value when divided by modulus.
+        """
+
+        super().__init__(model_name, name)
+
+        self.modulus = modulus
+        self.remainder = remainder
+
+    def state_forwards(self, app_label, state):
+        model = state.models[(app_label, self.model_name_lower)]
+        model.add_partition(
+            PostgresHashPartitionState(
+                app_label=app_label,
+                model_name=self.model_name,
+                name=self.name,
+                modulus=self.modulus,
+                remainder=self.remainder,
+            )
+        )
+
+        state.reload_model(app_label, self.model_name_lower)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            schema_editor.add_hash_partition(
+                model, self.name, self.modulus, self.remainder
+            )
+
+    def database_backwards(
+        self, app_label, schema_editor, from_state, to_state
+    ):
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            schema_editor.delete_partition(model, self.name)
+
+    def deconstruct(self):
+        name, args, kwargs = super().deconstruct()
+
+        kwargs["modulus"] = self.modulus
+        kwargs["remainder"] = self.remainder
+
+        return name, args, kwargs
+
+    def describe(self) -> str:
+        return "Creates hash partition %s on %s" % (self.name, self.model_name)

--- a/psqlextra/backend/migrations/operations/add_hash_partition.py
+++ b/psqlextra/backend/migrations/operations/add_hash_partition.py
@@ -4,13 +4,16 @@ from .partition import PostgresPartitionOperation
 
 
 class PostgresAddHashPartition(PostgresPartitionOperation):
-    """
-    Adds a new hash partition to a :see:PartitionedPostgresModel.
-    Each partition will hold the rows for which the hash value of the partition
-    key divided by the specified modulus will produce the specified remainder.
+    """Adds a new hash partition to a :see:PartitionedPostgresModel.
+
+    Each partition will hold the rows for which the hash value of the
+    partition key divided by the specified modulus will produce the
+    specified remainder.
     """
 
-    def __init__(self, model_name: str, name: str, modulus: int, remainder: int):
+    def __init__(
+        self, model_name: str, name: str, modulus: int, remainder: int
+    ):
         """Initializes new instance of :see:AddHashPartition.
         Arguments:
             model_name:

--- a/psqlextra/backend/migrations/operations/create_partitioned_model.py
+++ b/psqlextra/backend/migrations/operations/create_partitioned_model.py
@@ -69,3 +69,19 @@ class PostgresCreatePartitionedModel(CreateModel):
         description = super().describe()
         description = description.replace("model", "partitioned model")
         return description
+
+    def reduce(self, *args, **kwargs):
+        result = super().reduce(*args, **kwargs)
+
+        # replace CreateModel operation with PostgresCreatePartitionedModel
+        if isinstance(result, list) and result:
+            for i, op in enumerate(result):
+                if isinstance(op, CreateModel):
+                    _, args, kwargs = op.deconstruct()
+                    result[i] = PostgresCreatePartitionedModel(
+                        *args,
+                        **kwargs,
+                        partitioning_options=self.partitioning_options
+                    )
+
+        return result

--- a/psqlextra/backend/migrations/operations/delete_hash_partition.py
+++ b/psqlextra/backend/migrations/operations/delete_hash_partition.py
@@ -1,0 +1,29 @@
+from .delete_partition import PostgresDeletePartition
+
+
+class PostgresDeleteHashPartition(PostgresDeletePartition):
+    """Deletes a hash partition that's part of a.
+
+    :see:PartitionedPostgresModel.
+    """
+
+    def database_backwards(
+        self, app_label, schema_editor, from_state, to_state
+    ):
+        model = to_state.apps.get_model(app_label, self.model_name)
+        model_state = to_state.models[(app_label, self.model_name_lower)]
+
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            partition_state = model_state.partitions[self.name]
+            schema_editor.add_hash_partition(
+                model,
+                partition_state.name,
+                partition_state.modulus,
+                partition_state.remainder,
+            )
+
+    def describe(self) -> str:
+        return "Deletes hash partition '%s' on %s" % (
+            self.name,
+            self.model_name,
+        )

--- a/psqlextra/backend/migrations/operations/partition.py
+++ b/psqlextra/backend/migrations/operations/partition.py
@@ -26,3 +26,7 @@ class PostgresPartitionOperation(Operation):
 
     def state_backwards(self, *args, **kwargs):
         pass
+
+    def reduce(self, *args, **kwargs):
+        # PartitionOperation doesn't break migrations optimizations
+        return True

--- a/psqlextra/backend/migrations/patched_autodetector.py
+++ b/psqlextra/backend/migrations/patched_autodetector.py
@@ -8,7 +8,6 @@ from django.db.migrations import (
     DeleteModel,
     RemoveField,
     RenameField,
-    RunSQL,
 )
 from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.operations.base import Operation
@@ -19,6 +18,7 @@ from psqlextra.models import (
     PostgresPartitionedModel,
     PostgresViewModel,
 )
+from psqlextra.types import PostgresPartitioningMethod
 
 from . import operations
 
@@ -140,11 +140,12 @@ class AddOperationHandler:
         partitioning_options = model._partitioning_meta.original_attrs
         _, args, kwargs = operation.deconstruct()
 
-        self.add(
-            operations.PostgresAddDefaultPartition(
-                model_name=model.__name__, name="default"
+        if partitioning_options["method"] != PostgresPartitioningMethod.HASH:
+            self.add(
+                operations.PostgresAddDefaultPartition(
+                    model_name=model.__name__, name="default"
+                )
             )
-        )
 
         self.add(
             operations.PostgresCreatePartitionedModel(

--- a/psqlextra/backend/migrations/state/__init__.py
+++ b/psqlextra/backend/migrations/state/__init__.py
@@ -1,5 +1,6 @@
 from .materialized_view import PostgresMaterializedViewModelState
 from .partitioning import (
+    PostgresHashPartitionState,
     PostgresListPartitionState,
     PostgresPartitionedModelState,
     PostgresPartitionState,
@@ -10,6 +11,7 @@ from .view import PostgresViewModelState
 __all__ = [
     "PostgresPartitionState",
     "PostgresRangePartitionState",
+    "PostgresHashPartitionState",
     "PostgresListPartitionState",
     "PostgresPartitionedModelState",
     "PostgresViewModelState",

--- a/psqlextra/backend/migrations/state/partitioning.py
+++ b/psqlextra/backend/migrations/state/partitioning.py
@@ -38,6 +38,24 @@ class PostgresListPartitionState(PostgresPartitionState):
         self.values = values
 
 
+class PostgresHashPartitionState(PostgresPartitionState):
+    """Represents the state of a hash partition for a
+    :see:PostgresPartitionedModel during a migration."""
+
+    def __init__(
+        self,
+        app_label: str,
+        model_name: str,
+        name: str,
+        modulus: int,
+        remainder: int,
+    ):
+        super().__init__(app_label, model_name, name)
+
+        self.modulus = modulus
+        self.remainder = remainder
+
+
 class PostgresPartitionedModelState(PostgresModelState):
     """Represents the state of a :see:PostgresPartitionedModel in the
     migrations."""

--- a/psqlextra/types.py
+++ b/psqlextra/types.py
@@ -35,3 +35,4 @@ class PostgresPartitioningMethod(StrEnum):
 
     RANGE = "range"
     LIST = "list"
+    HASH = "hash"

--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "Django>=2.0",
-        "enforce>=0.3.4,<=1.0.0",
         "python-dateutil>=2.8.0,<=3.0.0",
-        "structlog>=19,<=20.1.0",
         "ansimarkup>=1.4.0,<=2.0.0",
     ],
     extras_require={

--- a/tests/test_make_migrations.py
+++ b/tests/test_make_migrations.py
@@ -37,6 +37,12 @@ from .migrations import apply_migration, make_migration
                 method=PostgresPartitioningMethod.RANGE, key="timestamp"
             ),
         ),
+        dict(
+            fields={"artist_id": models.IntegerField()},
+            partitioning_options=dict(
+                method=PostgresPartitioningMethod.HASH, key="artist_id"
+            )
+        )
     ],
 )
 @postgres_patched_migrations()

--- a/tests/test_migration_operations.py
+++ b/tests/test_migration_operations.py
@@ -209,6 +209,15 @@ def test_migration_operations_add_partition(
             ),
         ),
         (
+            PostgresPartitioningMethod.LIST,
+            operations.PostgresAddListPartition(
+                model_name="test", name="pt1", values=["car", "boat"]
+            ),
+            operations.PostgresDeleteListPartition(
+                model_name="test", name="pt1"
+            ),
+        ),
+        (
             PostgresPartitioningMethod.HASH,
             operations.PostgresAddHashPartition(
                 model_name="test", name="pt1", modulus=3, remainder=0

--- a/tests/test_migration_operations.py
+++ b/tests/test_migration_operations.py
@@ -63,9 +63,14 @@ def create_model():
         if method == PostgresPartitioningMethod.RANGE:
             key.append("timestamp")
             fields.append(("timestamp", models.DateTimeField()))
-        else:
+        elif method == PostgresPartitioningMethod.LIST:
             key.append("category")
             fields.append(("category", models.TextField()))
+        elif method == PostgresPartitioningMethod.HASH:
+            key.append("artist_id")
+            fields.append(("artist_id", models.IntegerField()))
+        else:
+            raise NotImplementedError
 
         return operations.PostgresCreatePartitionedModel(
             "test",
@@ -150,6 +155,12 @@ def test_migration_operations_delete_partitioned_table(method, create_model):
                 model_name="test", name="pt1", values=["car", "boat"]
             ),
         ),
+        (
+            PostgresPartitioningMethod.HASH,
+            operations.PostgresAddHashPartition(
+                model_name="test", name="pt1", modulus=3, remainder=0
+            ),
+        ),
     ],
 )
 def test_migration_operations_add_partition(
@@ -198,11 +209,11 @@ def test_migration_operations_add_partition(
             ),
         ),
         (
-            PostgresPartitioningMethod.LIST,
-            operations.PostgresAddListPartition(
-                model_name="test", name="pt1", values=["car", "boat"]
+            PostgresPartitioningMethod.HASH,
+            operations.PostgresAddHashPartition(
+                model_name="test", name="pt1", modulus=3, remainder=0
             ),
-            operations.PostgresDeleteListPartition(
+            operations.PostgresDeleteHashPartition(
                 model_name="test", name="pt1"
             ),
         ),


### PR DESCRIPTION
Hash partitioning support (PG >= 11).

The table is partitioned by specifying a modulus and a remainder for each partition. Each partition will hold the rows for which the hash value of the partition key divided by the specified modulus will produce the specified remainder. ()

Additional changes:
- remove unused dependencies
- possible fix for #123  
- fix reducing (PostgresCreatePartitionedModel operation is replaced by CreateModel operation after optimization)