### PR TITLE
Fix bulk_insert with json fields when return_model=True

### DIFF
--- a/psqlextra/query.py
+++ b/psqlextra/query.py
@@ -168,7 +168,9 @@ class PostgresQuerySet(models.QuerySet):
         objs = compiler.execute_sql(return_id=True)
         if return_model:
             return [
-                self._create_model_instance(dict(row, **obj), compiler.using)
+                self._create_model_instance(
+                    dict(row, **obj), compiler.using, apply_converters=False
+                )
                 for row, obj in zip(deduped_rows, objs)
             ]
         else:


### PR DESCRIPTION
This is a speculative fix for https://github.com/SectorLabs/django-postgres-extra/issues/158.  

Tests run locally, but I haven't added an explicit test for the bug that this solves. 