### PR TITLE
Fix missing import in table_partitioning.rst

### DIFF
--- a/docs/source/table_partitioning.rst
+++ b/docs/source/table_partitioning.rst
@@ -139,6 +139,7 @@ Time-based partitioning
        PostgresTimePartitionSize,
        partition_by_current_time,
    )
+   from psqlextra.partitioning.config import PostgresPartitioningConfig
 
    manager = PostgresPartitioningManager([
        # 3 partitions ahead, each partition is one month


### PR DESCRIPTION
Just found another small issue. 

Thanks for the new partitioning docs! I'm using django-postgres-extra for the first time and so far everything works great :crossed_fingers:
