### PR TITLE
Add PostgresAddCheckConstraintConcurrently

### DIFF
--- a/psqlextra/backend/migrations/operations/__init__.py
+++ b/psqlextra/backend/migrations/operations/__init__.py
@@ -1,3 +1,6 @@
+from .add_check_constraint_concurrently import (
+    PostgresAddCheckConstraintConcurrently,
+)
 from .add_default_partition import PostgresAddDefaultPartition
 from .add_hash_partition import PostgresAddHashPartition
 from .add_list_partition import PostgresAddListPartition
@@ -30,4 +33,5 @@ __all__ = [
     "PostgresCreateMaterializedViewModel",
     "PostgresDeleteViewModel",
     "PostgresDeleteMaterializedViewModel",
+    "PostgresAddCheckConstraintConcurrently",
 ]

--- a/psqlextra/backend/migrations/operations/add_check_constraint_concurrently.py
+++ b/psqlextra/backend/migrations/operations/add_check_constraint_concurrently.py
@@ -1,0 +1,47 @@
+from django.db.migrations.operations import AddConstraint
+from django.db.models import CheckConstraint
+
+
+class PostgresAddCheckConstraintConcurrently(AddConstraint):
+    """Adds a new :see:CheckConstraint without acquiring a Access Exclusive
+    table lock while the check is being validated for existing rows.
+
+    This MUST be run in a non-atomic migration.
+
+    This works by first adding the constraint with
+    NOT VALID. This causes the constraint to only
+    apply to new rows. This does acquire a Access
+    Exclusive lock, but it's short-lived as no
+    checking of existing rows has to be performed.
+
+    Next, the constraint is validated for all existing
+    rows. This requires only row-level locks.
+
+    If this operation is run a a transaction (atomic
+    migration), it will be no better then using
+    the standard :see:AddConstraint operation.
+    """
+
+    atomic = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        if not isinstance(self.constraint, CheckConstraint):
+            raise TypeError(
+                "PostgresAddCheckConstraintConcurrently can only be used with check constraints."
+            )
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+
+        schema_editor.add_constraint_not_valid(model, self.constraint)
+        schema_editor.validate_constraint(model, self.constraint)
+
+    def describe(self) -> str:
+        return "Create constraint %s concurrently on model %s" % (
+            self.constraint.name,
+            self.model_name,
+        )

--- a/tests/test_add_check_constraint_concurrently.py
+++ b/tests/test_add_check_constraint_concurrently.py
@@ -1,0 +1,51 @@
+from unittest.mock import call
+
+import pytest
+
+from django.db import models
+from django.db.models import CheckConstraint, Q, UniqueConstraint
+
+from psqlextra.backend.migrations.operations import (
+    PostgresAddCheckConstraintConcurrently,
+)
+
+from .fake_model import get_fake_model
+from .migrations import apply_migration, filtered_schema_editor
+
+
+def test_add_check_constraint_concurrently():
+    model = get_fake_model({"name": models.TextField()})
+    constraint = CheckConstraint(name="mycheck", check=Q(name__gt=2))
+
+    operation = PostgresAddCheckConstraintConcurrently(
+        model_name=model.__name__,
+        constraint=constraint,
+    )
+
+    assert not operation.atomic
+
+    with filtered_schema_editor("NOT VALID", "VALIDATE") as calls:
+        apply_migration([operation])
+
+    assert calls["NOT VALID"] == [
+        call(
+            'ALTER TABLE "%s" ADD CONSTRAINT "mycheck" CHECK ("name" > \'2\') NOT VALID;'
+            % model._meta.db_table,
+            params=None,
+        )
+    ]
+    assert calls["VALIDATE"] == [
+        call(
+            'ALTER TABLE "%s" VALIDATE CONSTRAINT "mycheck"'
+            % model._meta.db_table,
+            params=None,
+        )
+    ]
+
+
+def test_add_check_constraint_concurrently_not_check():
+    with pytest.raises(TypeError):
+        PostgresAddCheckConstraintConcurrently(
+            model_name="mymodel",
+            constraint=UniqueConstraint(name="myunique", fields=["a"]),
+        )

--- a/tests/test_schema_editor.py
+++ b/tests/test_schema_editor.py
@@ -1,0 +1,45 @@
+import pytest
+
+from django.db import connection, models
+from django.db.models import CheckConstraint, Q, UniqueConstraint
+
+from psqlextra.backend.schema import PostgresSchemaEditor
+
+from .fake_model import get_fake_model
+
+
+def test_schema_editor_add_constraint_not_valid():
+    model = get_fake_model({"name": models.TextField()})
+    constraint = CheckConstraint(name="mycheck", check=Q(name__gt=2))
+
+    schema_editor = PostgresSchemaEditor(connection, collect_sql=True)
+    schema_editor.add_constraint_not_valid(model, constraint)
+
+    assert schema_editor.collected_sql == [
+        'ALTER TABLE "%s" ADD CONSTRAINT "mycheck" CHECK ("name" > \'2\') NOT VALID;'
+        % model._meta.db_table
+    ]
+
+
+def test_schema_editor_add_constraint_not_valid_non_check_constraint():
+    model = get_fake_model({"name": models.TextField()})
+    constraint = UniqueConstraint(name="myunique", fields=["a"])
+
+    schema_editor = PostgresSchemaEditor(connection, collect_sql=True)
+
+    with pytest.raises(TypeError):
+        schema_editor.add_constraint_not_valid(model, constraint)
+
+    assert schema_editor.collected_sql == []
+
+
+def test_schema_editor_validate_constraint():
+    model = get_fake_model({"name": models.TextField()})
+    constraint = CheckConstraint(name="mycheck", check=Q(name__gt=2))
+
+    schema_editor = PostgresSchemaEditor(connection, collect_sql=True)
+    schema_editor.validate_constraint(model, constraint)
+
+    assert schema_editor.collected_sql == [
+        'ALTER TABLE "%s" VALIDATE CONSTRAINT "mycheck";' % model._meta.db_table
+    ]


### PR DESCRIPTION
A new operation that can add a check constraint on
an existing table without holding an Access Exclusive
lock for a long time.