### PR TITLE
Support both psqlextra and PostGis backends at the same time

### DIFF
--- a/psqlextra/backend/base.py
+++ b/psqlextra/backend/base.py
@@ -31,7 +31,7 @@ class DatabaseWrapper(base_impl.backend()):
         #
         # This can lead to broken functionality. We fix this automatically.
 
-        if not isinstance(self.ops, self.introspection_class):
+        if not isinstance(self.introspection, self.introspection_class):
             self.introspection = self.introspection_class(self)
 
         if not isinstance(self.ops, self.ops_class):

--- a/psqlextra/backend/base.py
+++ b/psqlextra/backend/base.py
@@ -22,7 +22,20 @@ class DatabaseWrapper(base_impl.backend()):
     introspection_class = PostgresIntrospection
     ops_class = PostgresOperations
 
-    def prepare_database(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not isinstance(self.ops, PostgresOperations):
+            # PostGis replaces the ops object instead of setting the ops_class attribute
+            if self.ops.compiler_module != 'django.db.models.sql.compiler':
+                raise NotImplementedError(
+                    f'''The Django ops object has been replaced by {self.ops} and a custom compiler module {self.ops.compiler_module} has been set.
+Replacing both at the same time is incompatible with psqlextra. '''
+                )
+            self.ops._compiler_cache = None
+            self.ops.compiler_module = 'psqlextra.compiler'
+
+
+def prepare_database(self):
         """Ran to prepare the configured database.
 
         This is where we enable the `hstore` extension if it wasn't

--- a/psqlextra/backend/base_impl.py
+++ b/psqlextra/backend/base_impl.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -23,7 +24,7 @@ def backend():
     base_class_name = getattr(
         settings,
         "POSTGRES_EXTRA_DB_BACKEND_BASE",
-        "django.db.backends.postgresql",
+        os.environ.get("POSTGRES_EXTRA_DB_BACKEND_BASE") or "django.db.backends.postgresql",
     )
 
     base_class_module = importlib.import_module(base_class_name + ".base")

--- a/psqlextra/backend/operations.py
+++ b/psqlextra/backend/operations.py
@@ -1,9 +1,11 @@
+from importlib import import_module
+
 from psqlextra.compiler import (
-    PostgresAggregateCompiler,
-    PostgresCompiler,
-    PostgresDeleteCompiler,
-    PostgresInsertCompiler,
-    PostgresUpdateCompiler,
+    SQLAggregateCompiler,
+    SQLCompiler,
+    SQLDeleteCompiler,
+    SQLInsertCompiler,
+    SQLUpdateCompiler,
 )
 
 from . import base_impl
@@ -11,14 +13,6 @@ from . import base_impl
 
 class PostgresOperations(base_impl.operations()):
     """Simple operations specific to PostgreSQL."""
-
-    compiler_map = {
-        "SQLCompiler": PostgresCompiler,
-        "SQLInsertCompiler": PostgresInsertCompiler,
-        "SQLUpdateCompiler": PostgresUpdateCompiler,
-        "SQLDeleteCompiler": PostgresDeleteCompiler,
-        "SQLAggregateCompiler": PostgresAggregateCompiler,
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -28,9 +22,8 @@ class PostgresOperations(base_impl.operations()):
     def compiler(self, compiler_name: str):
         """Gets the SQL compiler with the specified name."""
 
-        postgres_compiler = self.compiler_map.get(compiler_name)
-        if postgres_compiler:
-            return postgres_compiler
+        if self._cache is None:
+            self._cache = import_module('psqlextra.compiler')
 
-        # Let Django try to find the compiler. Better run without caller comment than break
-        return super().compiler(compiler_name)
+        # Let any parent module try to find the compiler as fallback. Better run without caller comment than break
+        return getattr(self._cache, compiler_name, super().compiler(compiler_name))

--- a/psqlextra/backend/operations.py
+++ b/psqlextra/backend/operations.py
@@ -1,5 +1,3 @@
-from importlib import import_module
-
 from psqlextra.compiler import (
     SQLAggregateCompiler,
     SQLCompiler,
@@ -14,16 +12,12 @@ from . import base_impl
 class PostgresOperations(base_impl.operations()):
     """Simple operations specific to PostgreSQL."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    compiler_module = "psqlextra.compiler"
 
-        self._compiler_cache = None
-
-    def compiler(self, compiler_name: str):
-        """Gets the SQL compiler with the specified name."""
-
-        if self._cache is None:
-            self._cache = import_module('psqlextra.compiler')
-
-        # Let any parent module try to find the compiler as fallback. Better run without caller comment than break
-        return getattr(self._cache, compiler_name, super().compiler(compiler_name))
+    compiler_classes = [
+        SQLCompiler,
+        SQLDeleteCompiler,
+        SQLAggregateCompiler,
+        SQLUpdateCompiler,
+        SQLInsertCompiler,
+    ]

--- a/psqlextra/compiler.py
+++ b/psqlextra/compiler.py
@@ -12,11 +12,11 @@ from django.core.exceptions import SuspiciousOperation
 from django.db.models import Expression, Model, Q
 from django.db.models.fields.related import RelatedField
 from django.db.models.sql.compiler import (
-    SQLAggregateCompiler,
-    SQLCompiler,
-    SQLDeleteCompiler,
-    SQLInsertCompiler,
-    SQLUpdateCompiler,
+    SQLAggregateCompiler as DjangoSQLAggregateCompiler,
+    SQLCompiler as DjangoSQLCompiler,
+    SQLDeleteCompiler as DjangoSQLDeleteCompiler,
+    SQLInsertCompiler as DjangoSQLInsertCompiler,
+    SQLUpdateCompiler as DjangoSQLUpdateCompiler,
 )
 from django.db.utils import ProgrammingError
 
@@ -77,25 +77,25 @@ def append_caller_to_sql(sql):
         return sql
 
 
-class PostgresCompiler(SQLCompiler):
+class SQLCompiler(DjangoSQLCompiler):
     def as_sql(self, *args, **kwargs):
         sql, params = super().as_sql(*args, **kwargs)
         return append_caller_to_sql(sql), params
 
 
-class PostgresDeleteCompiler(SQLDeleteCompiler):
+class SQLDeleteCompiler(DjangoSQLDeleteCompiler):
     def as_sql(self, *args, **kwargs):
         sql, params = super().as_sql(*args, **kwargs)
         return append_caller_to_sql(sql), params
 
 
-class PostgresAggregateCompiler(SQLAggregateCompiler):
+class SQLAggregateCompiler(DjangoSQLAggregateCompiler):
     def as_sql(self, *args, **kwargs):
         sql, params = super().as_sql(*args, **kwargs)
         return append_caller_to_sql(sql), params
 
 
-class PostgresUpdateCompiler(SQLUpdateCompiler):
+class SQLUpdateCompiler(DjangoSQLUpdateCompiler):
     """Compiler for SQL UPDATE statements that allows us to use expressions
     inside HStore values.
 
@@ -152,7 +152,7 @@ class PostgresUpdateCompiler(SQLUpdateCompiler):
         return False
 
 
-class PostgresInsertCompiler(SQLInsertCompiler):
+class SQLInsertCompiler(DjangoSQLInsertCompiler):
     """Compiler for SQL INSERT statements."""
 
     def as_sql(self, *args, **kwargs):
@@ -165,7 +165,7 @@ class PostgresInsertCompiler(SQLInsertCompiler):
         return queries
 
 
-class PostgresInsertOnConflictCompiler(SQLInsertCompiler):
+class PostgresInsertOnConflictCompiler(DjangoSQLInsertCompiler):
     """Compiler for SQL INSERT statements."""
 
     def __init__(self, *args, **kwargs):
@@ -407,7 +407,7 @@ class PostgresInsertOnConflictCompiler(SQLInsertCompiler):
         if isinstance(field, RelatedField) and isinstance(value, Model):
             value = value.pk
 
-        return SQLInsertCompiler.prepare_value(
+        return DjangoSQLInsertCompiler.prepare_value(
             self,
             field,
             # Note: this deliberately doesn't use `pre_save_val` as we don't

--- a/psqlextra/sql.py
+++ b/psqlextra/sql.py
@@ -8,7 +8,7 @@ from django.db import connections, models
 from django.db.models import sql
 from django.db.models.constants import LOOKUP_SEP
 
-from .compiler import PostgresInsertOnConflictCompiler, PostgresUpdateCompiler
+from .compiler import PostgresInsertOnConflictCompiler, SQLUpdateCompiler as PostgresUpdateCompiler
 from .expressions import HStoreColumn
 from .fields import HStoreField
 from .types import ConflictAction

--- a/psqlextra/sql.py
+++ b/psqlextra/sql.py
@@ -8,7 +8,8 @@ from django.db import connections, models
 from django.db.models import sql
 from django.db.models.constants import LOOKUP_SEP
 
-from .compiler import PostgresInsertOnConflictCompiler, SQLUpdateCompiler as PostgresUpdateCompiler
+from .compiler import PostgresInsertOnConflictCompiler
+from .compiler import SQLUpdateCompiler as PostgresUpdateCompiler
 from .expressions import HStoreColumn
 from .fields import HStoreField
 from .types import ConflictAction


### PR DESCRIPTION
*Work in Progress*

Problem (as discussed on Slack): PostGis lets Django create an Operations object from `ops_class` and then replaces `ops` with it's own Operations object:
```
class DatabaseWrapper(Psycopg2DatabaseWrapper):
    SchemaEditorClass = PostGISSchemaEditor

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        if kwargs.get("alias", "") != NO_DB_ALIAS:
            self.features = DatabaseFeatures(self)
            self.ops = PostGISOperations(self)
            self.introspection = PostGISIntrospection(self)
```
django/contrib/gis/db/backends/postgis/base.py ln. 12ff.

psqlextra relies on the wrapped Operations object overriding the `compiler` method. PostGis doesn't have a `compiler` method but inherits hard-coded from Django ignoring the `ops_class` setting:
```
class PostGISOperations(BaseSpatialOperations, DatabaseOperations):
```
django/contrib/gis/db/backends/postgis/operations.py ln. 112

The commit currently includes an env-to-settings import. pytest could be started with `POSTGRES_EXTRA_DB_BACKEND_BASE=django.contrib.gis.db.backends.postgis` to run with PostGis and without to leave it out. This is just for easy comparison and not intended to stay.

`tests/test_append_caller_to_sql.py` is sufficient to check if a patch is working.
`tests/test_management_command_partition.py` (and maybe other tests) fail with PostGis also without any changes from this PR.

[#181799346]