### PR TITLE
Fixing migration issue when the paritioning keys include the table primary key

### DIFF
--- a/psqlextra/backend/schema.py
+++ b/psqlextra/backend/schema.py
@@ -171,10 +171,16 @@ class PostgresSchemaEditor(base_impl.schema_editor()):
 
         # create a composite key that includes the partitioning key
         sql = sql.replace(" PRIMARY KEY", "")
-        sql = sql[:-1] + ", PRIMARY KEY (%s, %s))" % (
-            self.quote_name(model._meta.pk.name),
-            partitioning_key_sql,
-        )
+        if model._meta.pk.name not in meta.key:
+            sql = sql[:-1] + ", PRIMARY KEY (%s, %s))" % (
+                self.quote_name(model._meta.pk.name),
+                partitioning_key_sql,
+            )
+        else:
+            sql = sql[:-1] + ", PRIMARY KEY (%s))" % (
+                partitioning_key_sql,
+            )
+            
 
         # extend the standard CREATE TABLE statement with
         # 'PARTITION BY ...'


### PR DESCRIPTION
When the partitioning keys include the primary key there is an error during the model creation,
because the primary key is duplicated in the model.

Before fix we have this sql statement. 
`CREATE TABLE "mymodel" ("id" varchar(200) NOT NULL, .... , PRIMARY KEY ("id", "id")) PARTITION BY RANGE ("id");`
the primary key statement is incorrect!

After fix we have:
`CREATE TABLE "mymodel" ("id" varchar(200) NOT NULL, .... , PRIMARY KEY ("id")) PARTITION BY RANGE ("id");`
which is a valid statement