### PR TITLE
Add support for model tables on different Postgres schemas

### DIFF
--- a/psqlextra/backend/introspection.py
+++ b/psqlextra/backend/introspection.py
@@ -84,7 +84,7 @@ class PostgresIntrospection(base_impl.introspection()):
             (
                 table
                 for table in self.get_partitioned_tables(cursor)
-                if table.name == table_name
+                if table.name == table_name.split(".")[-1].lstrip('"')
             ),
             None,
         )


### PR DESCRIPTION
### Problem
Unable to use the command pgpartition if the model table is using a schema other than public

The model definition is something like this

```python
class MonthTimeseriesLong(PostgresPartitionedModel):
    """
    ... fields
    """
    class PartitioningMeta:
        method = PostgresPartitioningMethod.RANGE
        key = ["timestamp"]

    class Meta:
        ...
        db_table = 'timeseries"."tpa_ts_timeseries_long_month'
        ...

```

Migrations are working good and the tables are created in the right schema whern migrate is executed. However, pgpartition command fails after proposed partitions are accepted:

![image](https://user-images.githubusercontent.com/1476904/182650386-daa8a0c5-7176-476e-9878-199a2e4b44cf.png)

No table is found because the query made inside the method get_partitioned_tables of  PostgresIntrospection returns only the table name and the following strings are being compared:
`'timeseries"."tpa_ts_timeseries_long_month' == 'tpa_ts_timeseries_long_month'`

### Solution

Split by "." the table name defined on the model and trim remaining quotes in order to perform the comparison.

### Test results
#### tox
![image](https://user-images.githubusercontent.com/1476904/182653464-acb550e2-f6dc-4891-8e50-38082b799485.png)

#### benchmarks
![image](https://user-images.githubusercontent.com/1476904/182653724-51618357-ec24-4067-a6a7-1899383a8900.png)
