### PR TITLE
Fixed bulk_insert with zero rows

### DIFF
--- a/psqlextra/query.py
+++ b/psqlextra/query.py
@@ -163,6 +163,9 @@ class PostgresQuerySet(models.QuerySet):
                     continue
 
                 deduped_rows.append(row)
+        
+        if not deduped_rows:
+            return []
 
         compiler = self._build_insert_compiler(deduped_rows, using=using)
         objs = compiler.execute_sql(return_id=not return_model)


### PR DESCRIPTION
The issue mentioned in #132 still occurs. This fixes it, bringing behaviour in line with Django's `bulk_create` and other bulk functions, which exit early if no rows/objects are given.
