### PR TITLE
Make time partition suffix customizable

### DIFF
--- a/psqlextra/partitioning/current_time_strategy.py
+++ b/psqlextra/partitioning/current_time_strategy.py
@@ -24,6 +24,7 @@ class PostgresCurrentTimePartitioningStrategy(
         size: PostgresTimePartitionSize,
         count: int,
         max_age: Optional[relativedelta] = None,
+        name_format: Optional[str] = None,
     ) -> None:
         """Initializes a new instance of :see:PostgresTimePartitioningStrategy.
 
@@ -44,13 +45,16 @@ class PostgresCurrentTimePartitioningStrategy(
         self.size = size
         self.count = count
         self.max_age = max_age
+        self.name_format = name_format
 
     def to_create(self) -> Generator[PostgresTimePartition, None, None]:
         current_datetime = self.size.start(self.get_start_datetime())
 
         for _ in range(self.count):
             yield PostgresTimePartition(
-                start_datetime=current_datetime, size=self.size
+                start_datetime=current_datetime,
+                size=self.size,
+                name_format=self.name_format,
             )
 
             current_datetime += self.size.as_delta()
@@ -65,7 +69,9 @@ class PostgresCurrentTimePartitioningStrategy(
 
         while True:
             yield PostgresTimePartition(
-                start_datetime=current_datetime, size=self.size
+                start_datetime=current_datetime,
+                size=self.size,
+                name_format=self.name_format,
             )
 
             current_datetime -= self.size.as_delta()

--- a/psqlextra/partitioning/shorthands.py
+++ b/psqlextra/partitioning/shorthands.py
@@ -17,6 +17,7 @@ def partition_by_current_time(
     weeks: Optional[int] = None,
     days: Optional[int] = None,
     max_age: Optional[relativedelta] = None,
+    name_format: Optional[str] = None,
 ) -> PostgresPartitioningConfig:
     """Short-hand for generating a partitioning config that partitions the
     specified model by time.
@@ -48,6 +49,10 @@ def partition_by_current_time(
 
             Partitions older than this are deleted when running
             a delete/cleanup run.
+
+        name_format:
+            The datetime format which is being passed to datetime.strftime
+            to generate the partition name.
     """
 
     size = PostgresTimePartitionSize(
@@ -57,7 +62,10 @@ def partition_by_current_time(
     return PostgresPartitioningConfig(
         model=model,
         strategy=PostgresCurrentTimePartitioningStrategy(
-            size=size, count=count, max_age=max_age
+            size=size,
+            count=count,
+            max_age=max_age,
+            name_format=name_format,
         ),
     )
 

--- a/psqlextra/partitioning/time_partition.py
+++ b/psqlextra/partitioning/time_partition.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from .error import PostgresPartitioningError
 from .range_partition import PostgresRangePartition
@@ -22,7 +23,10 @@ class PostgresTimePartition(PostgresRangePartition):
     }
 
     def __init__(
-        self, size: PostgresTimePartitionSize, start_datetime: datetime
+        self,
+        size: PostgresTimePartitionSize,
+        start_datetime: datetime,
+        name_format: Optional[str] = None,
     ) -> None:
         end_datetime = start_datetime + size.as_delta()
 
@@ -34,9 +38,12 @@ class PostgresTimePartition(PostgresRangePartition):
         self.size = size
         self.start_datetime = start_datetime
         self.end_datetime = end_datetime
+        self.name_format = name_format
 
     def name(self) -> str:
-        name_format = self._unit_name_format.get(self.size.unit)
+        name_format = self.name_format or self._unit_name_format.get(
+            self.size.unit
+        )
         if not name_format:
             raise PostgresPartitioningError("Unknown size/unit")
 


### PR DESCRIPTION
An implementation attempt for #197

Usage example:

```python
manager = PostgresPartitioningManager(
    [
        PostgresPartitioningConfig(
            model=PartitionedMonthlyModel,
            strategy=CustomPostgresCurrentTimePartitioningStrategy(
                size=PostgresTimePartitionSize(months=1),
                count=3,
                name_format="%Y_%m",     # <--- new functionality
            ),
        ),
    ]
)
```

The change is fairly clean and it works, but design-wise I'm not sure if it is the right approach. Another possibility would be to add is as PostgresTimePartitionSize parameter, because the new parameter is "coupled to a specific size" (e.g. using `%Y_%m_%d` together with `PostgresTimePartitionSize(months=1)` does not really make sense). That said, `PostgresTimePartitionSize` is not  responsible for naming, so :man_shrugging: 


