### PR TITLE
feat: support for composite/sub partitioning

### DIFF
--- a/psqlextra/backend/schema.py
+++ b/psqlextra/backend/schema.py
@@ -146,7 +146,7 @@ class PostgresSchemaEditor(base_impl.schema_editor()):
         # table creations..
         sql, params = self._extract_sql(self.create_model, model)
 
-        partkeys = meta.key + getattr(meta, "subkey", [])
+        partkeys = meta.key + (getattr(meta, "subkey", None) or [])
         primary_key_sql = ", ".join(self.quote_name(field_name) for field_name in partkeys)
         partitioning_key_sql = ", ".join(self.quote_name(field_name) for field_name in meta.key)
 

--- a/psqlextra/backend/schema.py
+++ b/psqlextra/backend/schema.py
@@ -49,9 +49,6 @@ class PostgresSchemaEditor(base_impl.schema_editor()):
 
     def execute(self, sql, params=()):
         """execute query"""
-        # print(sql, params)
-        # if not raw:
-        #     return super().execute(sql, params)
         return super().execute(sql, params)
 
     def create_model(self, model: Model) -> None:
@@ -237,7 +234,6 @@ class PostgresSchemaEditor(base_impl.schema_editor()):
                 ", ".join(self.quote_name(field_name) for field_name in partition_by[1]),
             )
 
-        print("RANGE", sql)
         with transaction.atomic():
             self.execute(sql, (from_values, to_values))
 
@@ -302,7 +298,6 @@ class PostgresSchemaEditor(base_impl.schema_editor()):
                 ", ".join(self.quote_name(field_name) for field_name in partition_by[1]),
             )
 
-        print("LIST", sql)
         with transaction.atomic():
             self.execute(sql, values)
 
@@ -417,7 +412,6 @@ class PostgresSchemaEditor(base_impl.schema_editor()):
             self.quote_name(parent_table_name),
         )
 
-        print("DEFAULT", sql)
         with transaction.atomic():
             self.execute(sql)
 

--- a/psqlextra/management/commands/pgmakemigrations.py
+++ b/psqlextra/management/commands/pgmakemigrations.py
@@ -1,5 +1,4 @@
 from django.core.management.commands import makemigrations
-
 from psqlextra.backend.migrations import postgres_patched_migrations
 
 

--- a/psqlextra/models/options.py
+++ b/psqlextra/models/options.py
@@ -10,12 +10,20 @@ class PostgresPartitionedModelOptions:
     are held.
     """
 
-    def __init__(self, method: PostgresPartitioningMethod, key: List[str]):
+    def __init__(
+        self,
+        method: PostgresPartitioningMethod,
+        key: List[str],
+        submethod: PostgresPartitioningMethod | None = None,
+        subkey: List[str] | None = None,
+    ):
         self.method = method
         self.key = key
-        self.original_attrs: Dict[
-            str, Union[PostgresPartitioningMethod, List[str]]
-        ] = dict(method=method, key=key)
+        self.submethod = submethod
+        self.subkey = subkey
+        self.original_attrs: Dict[str, Union[None, PostgresPartitioningMethod, List[str]]] = dict(
+            method=method, key=key, submethod=submethod, subkey=subkey
+        )
 
 
 class PostgresViewOptions:
@@ -28,6 +36,4 @@ class PostgresViewOptions:
 
     def __init__(self, query: Optional[SQLWithParams]):
         self.query = query
-        self.original_attrs: Dict[str, Optional[SQLWithParams]] = dict(
-            query=self.query
-        )
+        self.original_attrs: Dict[str, Optional[SQLWithParams]] = dict(query=self.query)

--- a/psqlextra/models/partitioned.py
+++ b/psqlextra/models/partitioned.py
@@ -1,5 +1,4 @@
 from django.db.models.base import ModelBase
-
 from psqlextra.types import PostgresPartitioningMethod
 
 from .base import PostgresModel
@@ -23,18 +22,21 @@ class PostgresPartitionedModelMeta(ModelBase):
 
         method = getattr(meta_class, "method", None)
         key = getattr(meta_class, "key", None)
+        submethod = getattr(meta_class, "submethod", None)
+        subkey = getattr(meta_class, "subkey", None)
 
         patitioning_meta = PostgresPartitionedModelOptions(
-            method=method or cls.default_method, key=key or cls.default_key
+            method=method or cls.default_method,
+            key=key or cls.default_key,
+            subkey=subkey,
+            submethod=submethod,
         )
 
         new_class.add_to_class("_partitioning_meta", patitioning_meta)
         return new_class
 
 
-class PostgresPartitionedModel(
-    PostgresModel, metaclass=PostgresPartitionedModelMeta
-):
+class PostgresPartitionedModel(PostgresModel, metaclass=PostgresPartitionedModelMeta):
     """Base class for taking advantage of PostgreSQL's 11.x native support for
     table partitioning."""
 

--- a/psqlextra/partitioning/config.py
+++ b/psqlextra/partitioning/config.py
@@ -11,9 +11,11 @@ class PostgresPartitioningConfig:
         self,
         model: PostgresPartitionedModel,
         strategy: PostgresPartitioningStrategy,
+        substrategy: PostgresPartitioningStrategy | None = None,
     ) -> None:
         self.model = model
         self.strategy = strategy
+        self.substrategy = substrategy
 
 
 __all__ = ["PostgresPartitioningConfig"]

--- a/psqlextra/partitioning/partition.py
+++ b/psqlextra/partitioning/partition.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Optional
+from typing import List, Optional, Tuple
 
 from psqlextra.backend.schema import PostgresSchemaEditor
 from psqlextra.models import PostgresPartitionedModel
@@ -8,9 +8,18 @@ from psqlextra.models import PostgresPartitionedModel
 class PostgresPartition:
     """Base class for a PostgreSQL table partition."""
 
+    partition_by: Optional[Tuple[str, List[str]]] = None
+    parent_partition_name: Optional[str] = None
+
     @abstractmethod
     def name(self) -> str:
         """Generates/computes the name for this partition."""
+
+    def full_name(self) -> str:
+        """Concatenate the name with the parent_partition name (if needed)"""
+        if self.parent_partition_name:
+            return self.parent_partition_name + "_" + self.name()
+        return self.name()
 
     @abstractmethod
     def create(
@@ -32,7 +41,7 @@ class PostgresPartition:
     def deconstruct(self) -> dict:
         """Deconstructs this partition into a dict of attributes/fields."""
 
-        return {"name": self.name()}
+        return {"name": self.full_name()}
 
 
 __all__ = ["PostgresPartition"]

--- a/psqlextra/partitioning/plan.py
+++ b/psqlextra/partitioning/plan.py
@@ -51,12 +51,12 @@ class PostgresModelPartitioningPlan:
         print(f"{self.config.model.__name__}:")
 
         for partition in self.deletions:
-            print("  - %s" % partition.name())
+            print("  - %s" % partition.full_name())
             for key, value in partition.deconstruct().items():
                 print(f"     {key}: {value}")
 
         for partition in self.creations:
-            print("  + %s" % partition.name())
+            print("  + %s" % partition.full_name())
             for key, value in partition.deconstruct().items():
                 print(f"     {key}: {value}")
 

--- a/psqlextra/partitioning/range_partition.py
+++ b/psqlextra/partitioning/range_partition.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, List, Optional, Tuple
 
 from psqlextra.backend.schema import PostgresSchemaEditor
 from psqlextra.models import PostgresPartitionedModel
@@ -29,10 +29,12 @@ class PostgresRangePartition(PostgresPartition):
     ) -> None:
         schema_editor.add_range_partition(
             model=model,
-            name=self.name(),
+            name=self.full_name(),
             from_values=self.from_values,
             to_values=self.to_values,
             comment=comment,
+            partition_by=self.partition_by,
+            parent_partition_name=self.parent_partition_name,
         )
 
     def delete(


### PR DESCRIPTION
Hello,

I needed to have composite partitioning (aka nested or subpartitioning),
I made the changes to make it work for one level subpartitioning.

The principal changes are:
1) Handling "submethod" and "subkey" variable in the partitioning meta object
2) Adding partition_by and parent_partition_name in the PostgresPartition class to make it aware that it could have either parent or child partition (and add the PARTITION OF and PARTITION BY sql statement where needed)
3) Adding a submethod in the Config to handle how the second level should be created
4) Updating the manager to create a second level of partition if needed

I tested the code with TimePartitioning at first level and a List partitioning at second level,  it's working nicely.

The code could certainly be improved, but the functionality is there and it would certainly be useful to others to have it in the main package.  Thanks for considering its inclusion.
