### PR TITLE
chore(): Add missing python versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],


### PR DESCRIPTION
Add missing python versions in `setup.py`.

While this library supports python 3.10 and 3.11, it doesn't appear on the [official pypi page].(https://pypi.org/project/django-postgres-extra/).