### PR TITLE
feat(partitioning): add per partition constraints

### DIFF
--- a/psqlextra/models/options.py
+++ b/psqlextra/models/options.py
@@ -1,5 +1,7 @@
 from typing import Dict, List, Optional, Union
 
+from django.db.models import BaseConstraint
+
 from psqlextra.types import PostgresPartitioningMethod, SQLWithParams
 
 
@@ -10,12 +12,15 @@ class PostgresPartitionedModelOptions:
     are held.
     """
 
-    def __init__(self, method: PostgresPartitioningMethod, key: List[str]):
+    def __init__(
+            self, method: PostgresPartitioningMethod, key: List[str], per_partition_constraints: list[BaseConstraint]
+    ):
         self.method = method
         self.key = key
         self.original_attrs: Dict[
             str, Union[PostgresPartitioningMethod, List[str]]
         ] = dict(method=method, key=key)
+        self.per_partition_constraints = per_partition_constraints or []
 
 
 class PostgresViewOptions:

--- a/psqlextra/models/partitioned.py
+++ b/psqlextra/models/partitioned.py
@@ -25,9 +25,11 @@ class PostgresPartitionedModelMeta(ModelBase):
 
         method = getattr(meta_class, "method", None)
         key = getattr(meta_class, "key", None)
+        per_partition_constraints = getattr(meta_class, "per_partition_constraints", [])
 
         patitioning_meta = PostgresPartitionedModelOptions(
-            method=method or cls.default_method, key=key or cls.default_key
+            method=method or cls.default_method, key=key or cls.default_key,
+            per_partition_constraints=per_partition_constraints
         )
 
         new_class.add_to_class("_partitioning_meta", patitioning_meta)

--- a/psqlextra/partitioning/range_partition.py
+++ b/psqlextra/partitioning/range_partition.py
@@ -2,7 +2,6 @@ from typing import Any, Optional, Type
 
 from psqlextra.backend.schema import PostgresSchemaEditor
 from psqlextra.models import PostgresPartitionedModel
-
 from .partition import PostgresPartition
 
 


### PR DESCRIPTION
this pr allows to add constraints per partition 

our need was to add unique constraints not containing partition key per partition on a range partitioned model.

I added `add_constraints_to_partition` function which is called in `add_..._partition` functions