### PR TITLE
Add in Hourly Partition Support

### DIFF
--- a/docs/source/table_partitioning.rst
+++ b/docs/source/table_partitioning.rst
@@ -175,9 +175,9 @@ Time-based partitioning
            ),
        ),
 
-       # 24 partitions ahead, each partition is 1 hour
+       # 24 partitions ahead, each partition is 1 hour, for a total of 24 hours. Starting with hour 0 of current day
        # old partitions are never deleted, `max_age` is not set
-       # partitions will be named `[table_name]_[year]_[month]_[month day number]_[hour (24h)]`.
+       # partitions will be named `[table_name]_[year]_[month]_[month day number]_[hour (24h)]:00:00`.
        PostgresPartitioningConfig(
            model=MyPartitionedModel,
            strategy=PostgresCurrentTimePartitioningStrategy(

--- a/psqlextra/partitioning/current_time_strategy.py
+++ b/psqlextra/partitioning/current_time_strategy.py
@@ -16,7 +16,7 @@ class PostgresCurrentTimePartitioningStrategy(
 
     All buckets will be equal in size and start at the start of the
     unit. With monthly partitioning, partitions start on the 1st and
-    with weekly partitioning, partitions start on monday, with hourly 
+    with weekly partitioning, partitions start on monday, with hourly
     partitioning, partitions start at 00:00.
     """
 

--- a/psqlextra/partitioning/time_partition_size.py
+++ b/psqlextra/partitioning/time_partition_size.py
@@ -89,7 +89,7 @@ class PostgresTimePartitionSize:
 
         if self.unit == PostgresTimePartitionUnit.WEEKS:
             return self._ensure_datetime(dt - relativedelta(days=dt.weekday()))
-        
+
         if self.unit == PostgresTimePartitionUnit.DAYS:
             return self._ensure_datetime(dt)
 
@@ -97,7 +97,7 @@ class PostgresTimePartitionSize:
 
     @staticmethod
     def _ensure_datetime(dt: Union[date, datetime]) -> datetime:
-        return datetime(year=dt.year, month=dt.month, day=dt.day, hour = dt.hour)
+        return datetime(year=dt.year, month=dt.month, day=dt.day, hour=dt.hour)
 
     def __repr__(self) -> str:
         return "PostgresTimePartitionSize<%s, %s>" % (self.unit, self.value)

--- a/psqlextra/query.py
+++ b/psqlextra/query.py
@@ -591,7 +591,7 @@ class PostgresQuerySet(QuerySetBase, Generic[TModel]):
             has_default = field.default != NOT_PROVIDED
             if field.name in kwargs or field.column in kwargs:
                 insert_fields.append(field)
-                update_values[field.name] = ExcludedCol(field.column)
+                update_values[field.name] = ExcludedCol(field)
                 continue
             elif has_default:
                 insert_fields.append(field)
@@ -602,13 +602,13 @@ class PostgresQuerySet(QuerySetBase, Generic[TModel]):
             # instead of a concrete field, we have to handle that
             if field.primary_key is True and "pk" in kwargs:
                 insert_fields.append(field)
-                update_values[field.name] = ExcludedCol(field.column)
+                update_values[field.name] = ExcludedCol(field)
                 continue
 
             if self._is_magical_field(model_instance, field, is_insert=True):
                 insert_fields.append(field)
 
             if self._is_magical_field(model_instance, field, is_insert=False):
-                update_values[field.name] = ExcludedCol(field.column)
+                update_values[field.name] = ExcludedCol(field)
 
         return insert_fields, update_values

--- a/tests/test_partitioning_time.py
+++ b/tests/test_partitioning_time.py
@@ -254,7 +254,6 @@ def test_partitioning_time_daily_apply():
     assert table.partitions[6].name == "2019_jun_04"
 
 
-
 @pytest.mark.postgres_version(lt=110000)
 def test_partitioning_time_hourly_apply():
     """Tests whether automatically creating new partitions ahead hourly works as
@@ -446,7 +445,7 @@ def test_partitioning_time_hourly_apply_insert():
     assert len(table.partitions) == 2
 
     model.objects.create(timestamp=datetime.datetime(2019, 1, 7, 0))
-    model.objects.create(timestamp=datetime.datetime(2019, 1, 7 , 1))
+    model.objects.create(timestamp=datetime.datetime(2019, 1, 7, 1))
 
     with transaction.atomic():
         with pytest.raises(IntegrityError):


### PR DESCRIPTION
This PR adds support for Hourly partitions, using the existing time-based partitions functionality. 

I've added new unit tests, and all the old unit tests still pass. 

Also added an example in `docs/source/table_partitioning.rst`

When using hourly partitions, they start at 00:00 of any given day, in order to follow the pattern given by weekly and monthly partitions, which start on Monday and the 1st of the month respectively. 