### PR TITLE
Stop updating on conflict if `update_condition` is False but not None

### DIFF
--- a/psqlextra/query.py
+++ b/psqlextra/query.py
@@ -327,7 +327,9 @@ class PostgresQuerySet(QuerySetBase, Generic[TModel]):
 
         self.on_conflict(
             conflict_target,
-            ConflictAction.UPDATE,
+            ConflictAction.UPDATE
+            if (update_condition or update_condition is None)
+            else ConflictAction.NOTHING,
             index_predicate=index_predicate,
             update_condition=update_condition,
             update_values=update_values,


### PR DESCRIPTION
Some users of this library set `update_condition=0` on `upsert` for not updating anything on conflict.

The `upsert` documentation says:
> update_condition:
>   Only update if this SQL expression evaluates to true.

A value evaluating to Python `False` is ignored while the documentation says no update will be done.

[#186513018]