### PR TITLE
[fix]Fixing the bug that causes index migration failure in multi-sche…

### DIFF
--- a/psqlextra/backend/introspection.py
+++ b/psqlextra/backend/introspection.py
@@ -231,7 +231,7 @@ class PostgresIntrospection(Introspection):
         # standard Django implementation does not return the definition
         # for indexes, only for constraints, let's patch that up
         cursor.execute(
-            "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = %s",
+            "SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = current_schema() AND tablename = %s",
             (table_name,),
         )
         for index_name, definition in cursor.fetchall():


### PR DESCRIPTION
I think fixing it this way would be better, because in PostgreSQL, the pg_indexes view within the SQL SELECT indexname, indexdef FROM pg_indexes WHERE tablename = %s is used to display index information for all tables. When you execute this query, it returns indexes for all tables that meet the condition, regardless of whether these tables are within the current schema or not.