### PR TITLE
feat: Add option to run partition migration command outside transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist/
 
 # Ignore PyCharm / IntelliJ files
 .idea/
+*.iml

--- a/psqlextra/partitioning/config.py
+++ b/psqlextra/partitioning/config.py
@@ -13,9 +13,11 @@ class PostgresPartitioningConfig:
         self,
         model: Type[PostgresPartitionedModel],
         strategy: PostgresPartitioningStrategy,
+        atomic: bool = True,
     ) -> None:
         self.model = model
         self.strategy = strategy
+        self.atomic = atomic
 
 
 __all__ = ["PostgresPartitioningConfig"]


### PR DESCRIPTION
Having non atomic management command can help reduce lock contention.

In this PR a new `atomic` option has been added to the `PostgresPartitioningConfig` class. If set to false all changes will be done from outside a transaction. This option is set to `True` by default so it does not break retrocompatibility.