### PR TITLE
Allow tuples as a valid type for `meta.key`

### DIFF
--- a/psqlextra/backend/schema.py
+++ b/psqlextra/backend/schema.py
@@ -1045,7 +1045,7 @@ class PostgresSchemaEditor(SchemaEditor):
                 % (model.__name__, meta.method)
             )
 
-        if not isinstance(meta.key, list):
+        if not isinstance(meta.key, (list, tuple)):
             raise ImproperlyConfigured(
                 (
                     "Model '%s' is not properly configured to be partitioned."


### PR DESCRIPTION
Most modern linters (like `ruff`) will complain about `meta.key` being a list, as it's a mutable class variable. Allowing a tuple here appears to work fine and removes the need to override linter rules for `meta.key`.