### PR TITLE
Fix automatic hstore extension creation not working on Django 4.2 or newer

### DIFF
--- a/psqlextra/backend/base.py
+++ b/psqlextra/backend/base.py
@@ -3,6 +3,10 @@ import logging
 from typing import TYPE_CHECKING
 
 from django.conf import settings
+from django.contrib.postgres.signals import (
+    get_hstore_oids,
+    register_type_handlers,
+)
 from django.db import ProgrammingError
 
 from . import base_impl
@@ -94,3 +98,22 @@ class DatabaseWrapper(Wrapper):
                     "or add the extension manually.",
                     exc_info=True,
                 )
+                return
+
+        # Clear old (non-existent), stale oids.
+        get_hstore_oids.cache_clear()
+
+        # Verify that we (and Django) can find the OIDs
+        # for hstore.
+        oids, _ = get_hstore_oids(self.alias)
+        if not oids:
+            logger.warning(
+                '"hstore" extension was created, but we cannot find the oids'
+                "in the database. Something went wrong.",
+            )
+            return
+
+        # We must trigger Django into registering the type handlers now
+        # so that any subsequent code can properly use the newly
+        # registered types.
+        register_type_handlers(self)


### PR DESCRIPTION
The following change broke the auto setup:
https://github.com/django/django/commit/d3e746ace5eeea07216da97d9c3801f2fdc43223

This breaks because the call to `pscygop2.extras.register_hstore` is now
conditional. Before, it would be called multiple times with
empty OIDS, when eventually our auto registration would kick
in and psycopg2 would fetch the OIDs itself.